### PR TITLE
domin v 3.5.3

### DIFF
--- a/domin.ado
+++ b/domin.ado
@@ -1,13 +1,13 @@
-*! domin version 3.5.2  8/13/2024 Joseph N. Luchman
+*! domin version 3.5.3  12/20/2024 Joseph N. Luchman
 // version information at end of file
 **# Pre-program definition
 quietly include dominance.mata, adopath
 program define domin, eclass 
-if `c(version)' < 15 {
-	display "{err}As of {cmd:domin} version 3.5.0, the minimum version of Stata is 15." _newline "If you have an older version of Stata, most functionality of {cmd:domin} is available from" _newline `"{stata net install st0645:this} Stata journal article back to version 12."'
+if `c(version)' < 16 {
+	display "{err}As of {cmd:domin} version 3.5.3, the minimum version of Stata is 16." _newline "If you have an older version of Stata, most functionality of {cmd:domin} is available from" _newline `"{stata net install st0645:this} Stata journal article back to version 12."'
 	exit 198
 }
-version 15
+version 16
 if replay() {
 	if ("`e(cmd)'" != "domin") error 301
 	if _by() error 190
@@ -127,7 +127,7 @@ end
 /*Display program*/
 program define Display
 
-version 15
+version 16
 
 tempname domwgts sdomwgts ranks
 
@@ -263,7 +263,7 @@ if strlen("`e(all)'") display "{txt}Variables included in all sub-models: `e(all
 end
 
 **# Mata function adapting Stata input for Mata and initiating the Mata environment
-version 15
+version 16
 mata:
 mata set matastrict on
 void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, string scalar all, string scalar conditional, string scalar complete, string scalar epsilon, string scalar consmodel, string scalar reverse, string scalar esampleok, string scalar weight, string scalar inif, string scalar varlist) {
@@ -340,7 +340,7 @@ void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, s
 		}
 		
 		/*combine to single iv vector*/
-		if ( length(ivs) > 1 ) ivs = (ivs, iv_sets)
+		if ( length(ivs) > 0 ) ivs = (ivs, iv_sets)
 		else ivs = iv_sets
 	
 	}
@@ -581,7 +581,7 @@ void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, s
 end
 
 **# Mata function to execute 'domin-flavored' models
-version 15
+version 16
 
 mata:
 
@@ -607,7 +607,7 @@ mata:
 	
 end
 **# Mata function to execute built-in linear regression
-version 15
+version 16
 mata:
 mata set matastrict on
 real scalar domin_regress(string scalar IVs_in_model, class AssociativeArray scalar model_specs) { 
@@ -824,6 +824,9 @@ end
  - fixed error using -all- with factor or time-series variables with the built-in method (thanks to Felix Bittman)
  - -consmodel- not allowed with built-in regress method
  - -mi_dom- and factor- and time-series variable error fixes (thanks to katherine // kathy chan)
+ // 3.5.3 - December 20, 2024
+ -  version of all programs at a minimum to 16 to accommodate the use of usrsplit() which is not available before v 16
+ -  fixed error in checking number of IVs with a combinatoin of IVs and IV sets when there was only one IV
  ---
  
  future domin

--- a/domin.sthlp
+++ b/domin.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.5.2 August 13, 2024 J. N. Luchman}{...}
+{* *! version 3.5.3 December 20, 2024 J. N. Luchman}{...}
 {cmd:help domin}
 
 {title:Title}

--- a/dominance.mata
+++ b/dominance.mata
@@ -1,7 +1,7 @@
-*! dominance.mata version 0.1.0  8/14/2023 Joseph N. Luchman
+*! dominance.mata version 0.1.1  12/20/2024 Joseph N. Luchman
 
 **# Mata function to compute all combinations of predictors or predictor sets run all subsets regression, and compute all dominance criteria
-version 15
+version 16
 
 mata: 
 

--- a/domme.ado
+++ b/domme.ado
@@ -1,4 +1,4 @@
-*! domme version 1.2.0 1/12/2024 Joseph N. Luchman
+*! domme version 1.2.1 12/20/2024 Joseph N. Luchman
 // version information at end of file
 
 **# Pre-program definition
@@ -6,7 +6,7 @@ quietly include dominance.mata, adopath
 
 program define domme, eclass 
 
-	version 15
+	version 16
 
 	if replay() & !strlen("`0'") {
 
@@ -839,4 +839,8 @@ end
  - minimum version sync-ed with -domin- at 15 (not 15.1)
  - fixed issue with -all()- option; not consistent with documentation - required full 'all' typed (not 'a()')
  - estrella, aic and bic disallowed with built-in; mcfadden remains
+ // 1.2.1 - December 20, 2024
+ - version incremented to 16 consistent with base -domin-
+ // 1.2.2 - ....
+ ** planned  -- fixed parsing for outcomes to accommodate factor variables (gsem)
 */

--- a/domme.sthlp
+++ b/domme.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 January 12, 2024 J. N. Luchman}{...}
+{* *! version 1.2.1 December 20, 2024 J. N. Luchman}{...}
 {cmd:help domme}
 
 {title:Title}

--- a/fitdom.ado
+++ b/fitdom.ado
@@ -1,8 +1,8 @@
-*! fitdom version 0.1.0  8/14/2023 Joseph N. Luchman
+*! fitdom version 0.1.1  12/20/2024 Joseph N. Luchman
 
 program define fitdom, eclass //history and version information at end of file
 
-version 15
+version 16
 
 syntax varlist(min = 1 ts fv) if [aw pw iw fw] , [Reg_fd(string) Postestimation(string) Fitstat_fd(string)]
 
@@ -28,3 +28,5 @@ end
  ---
  fitdom version 0.1.0 - August 14, 2023
 -  minimum version 15 consistent with base -domin-
+// 0.1.1 - December 20, 2024
+-  minimum version to 16 consistent with base -domin-

--- a/fitdom.sthlp
+++ b/fitdom.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 0.1.0 August 14, 2023 J. N. Luchman}{...}
+{* *! version 0.1.1 December 20, 2023 J. N. Luchman}{...}
 {cmd:help fitdom}
 {hline}{...}
 

--- a/mi_dom.ado
+++ b/mi_dom.ado
@@ -1,8 +1,8 @@
-*! mi_dom version 0.0.2  8/13/2024 Joseph N. Luchman
+*! mi_dom version 0.0.3  12/20/2024 Joseph N. Luchman
 
 program define mi_dom, eclass //history and version information at end of file
 
-version 15
+version 16
 
 syntax varlist(min = 1 fv ts) if [aw fw iw pw], Reg_mi(string) Fitstat_mi(string) [MIOpt(string)] 
 
@@ -49,3 +49,5 @@ end
 // 0.0.2 - August 13, 2024
  - allows factor- and time-series variables - thanks to katherine // kathy chan for bug report
  - fix to documentation of -reg_mi()- option
+// 0.0.3 -December 20, 2024
+-  version to 16 consistent with base -domin-

--- a/mi_dom.sthlp
+++ b/mi_dom.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 0.0.2 August 13, 2024 J. N. Luchman}{...}
+{* *! version 0.0.3 December 20, 2024 J. N. Luchman}{...}
 {cmd:help mi_dom}
 {hline}{...}
 

--- a/mixdom.ado
+++ b/mixdom.ado
@@ -1,6 +1,6 @@
-*! mixdom version 2.1.0 8/14/2023 Joseph N. Luchman
+*! mixdom version 2.1.1 12/20/2024 Joseph N. Luchman
 
-version 15
+version 16
 
 program define mixdom, eclass
 
@@ -106,5 +106,7 @@ Basic version
  - xtmopt defunct - gives warning
  - noconstant option removed
  - returns e(smaple) to satisfy -domin- 3.5 requirements
+ // 2.1.1 - December 20, 2024
+ -  version to 16 consistent with base -domin-
  
  ** mi-able?

--- a/mixdom.sthlp
+++ b/mixdom.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 2.1.0 August 14, 2023 J. N. Luchman}{...}
+{* *! version 2.1.1 December 20, 2024 J. N. Luchman}{...}
 {cmd:help mixdom}
 {hline}{...}
 

--- a/mvdom.ado
+++ b/mvdom.ado
@@ -1,6 +1,6 @@
-*! mvdom version 1.2.0 8/14/2023 Joseph N. Luchman
+*! mvdom version 1.2.1 12/20/2024 Joseph N. Luchman
 
-version 15
+version 16
 
 program define mvdom, eclass
 
@@ -58,7 +58,7 @@ else {
 end
 
 /*Mata function to execute epsilon-based relative importance with mvdom*/
-version 15
+version 16
 
 mata: 
 
@@ -143,5 +143,7 @@ Basic version
  - removed noconstant option - not consistently applied, not sure why one would ever use it
  - unhide epsilon -  note that it produces Pxy as a metric
  - use st_view as opposed to st_data for efficiency
+ // 1.2.1 - December 20, 2024
+ -  version to 16 consistent with base -domin-
  
  ** mi-able?

--- a/mvdom.sthlp
+++ b/mvdom.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 August 14, 2023 J. N. Luchman}{...}
+{* *! version 1.2.1 December 20, 2024 J. N. Luchman}{...}
 {cmd:help mvdom}
 {hline}{...}
 


### PR DESCRIPTION
- minimum version to 16 to accommodate usrsplit()
- fix to IV and IV sets checks with one IV