### PR TITLE
To 3.6.0

### DIFF
--- a/domin.ado
+++ b/domin.ado
@@ -1,239 +1,179 @@
-*! domin version 3.5.3  12/20/2024 Joseph N. Luchman
-// version information at end of file
-**# Pre-program definition
+*! domin version 3.6.0  5/5/2025 Joseph N. Luchman
+**# -domin- API/as called from user
+// ~~~ pre-syntax requirements ~~~
+	// ~~ include dominance analysis 'engine' Mata code ~~
 quietly include dominance.mata, adopath
+	// ~~~ define -domin- and versioning ~~~
 program define domin, eclass 
 if `c(version)' < 16 {
-	display "{err}As of {cmd:domin} version 3.5.3, the minimum version of Stata is 16." _newline "If you have an older version of Stata, most functionality of {cmd:domin} is available from" _newline `"{stata net install st0645:this} Stata journal article back to version 12."'
+	display "{err}As of {cmd:domin} version 3.5.3, the minimum version of " ///
+	"Stata is 16." _newline "If you have an older version of Stata, most " ///
+	"functionality of {cmd:domin} is available from" _newline ///
+	`"{stata net install st0645:this}"' ///
+	" Stata journal article back to version 12."
 	exit 198
 }
 version 16
+	// ~~ allow replays ~~
 if replay() {
 	if ("`e(cmd)'" != "domin") error 301
 	if _by() error 190
 	Display `0'
 	exit 0
 }
-**# Program definition and argument checks
+// ~~~ set syntax ~~~
 syntax varlist(min = 1 ts) [in] [if] [aw pw iw fw] , ///
 	[Reg(string) Fitstat(string) Sets(string) All(varlist fv ts) ///
-	noCONditional noCOMplete EPSilon CONSmodel REVerse noESAMPleok mi miopt(string)] 
+	noCONditional noCOMplete EPSilon CONSmodel REVerse noESAMPleok ///
+	mi miopt(string)]
+// ~~~ option defaults ~~~
 if strlen("`epsilon'") {
 	local esampleok "esampleok"
 	local conditional "conditional"
 	local complete "complete"
 }
+// ~~~ option errors ~~~
 if strlen("`mi'") | strlen("`mi'") {
-	display "{err}{cmd:mi} and {opt miopt()} are depreciated. Please use {help mi_dom}."
+	display "{err}{cmd:mi} and {opt miopt()} are depreciated. " ///
+	"Please use {help mi_dom}."
 	exit 198
 }
-**# Wrapper process for -domin- processing in Mata
-mata: domin_2mata("`reg'", "`fitstat'", "`sets'", "`all'", "`conditional'", "`complete'", "`epsilon'", "`consmodel'", "`reverse'", "`esampleok'", "`weight'`exp'", "`in' `if'", "`varlist'")
-**# Ereturn processing
+// ~~~ Mata function implementing most processing and analysis ~~~
+mata: ///
+	domin_2mata("`reg'", "`fitstat'", "`sets'", "`all'", "`conditional'", ///
+	"`complete'", "`epsilon'", "`consmodel'", "`reverse'", "`esampleok'", ///
+	"`weight'`exp'", "`in' `if'", "`varlist'")
+// ~~~ returned values ~~~
+	// ~~ set container variariables and record titles ~~
 tempname domwgts cdldom cptdom stdzd ranks
-
 if !strlen("`epsilon'") & strlen("`e(title)'") local title "`e(title)'"
-
-else if strlen("`epsilon'") & strlen("`e(title)'") local title "Epsilon-based `reg'"
-
+else if strlen("`epsilon'") & strlen("`e(title)'") ///
+	local title "Epsilon-based `reg'"
 else local title "Custom user analysis"
-
+	// ~~ post primary ereturned values ~~
 matrix `domwgts' = r(domwgts)
-ereturn post `domwgts' [`weight'`exp'], depname(`dv') obs(`=r(N)') esample(`touse')
-
-**# Ereturn scalars
+ereturn post `domwgts' [`weight'`exp'], ///
+	depname(`dv') obs(`=r(N)') esample(`touse')
+	// ~~ post overall fitstat scalars ~~
 matrix `domwgts' = r(domwgts)*J(colsof(r(domwgts)), 1, 1)
 if strlen("`epsilon'") ereturn scalar fitstat_o = `=`domwgts'[1,1]'
 else ereturn scalar fitstat_o = `=r(fullfs) + r(allfs) + r(consfs)'
-
 if `:list sizeof all' ereturn scalar fitstat_a = `=r(allfs)'
 if strlen("`consmodel'") ereturn scalar fitstat_c = `=r(consfs)'
-
+	// ~~ set records ~~
 if strlen("`setcount'") {
-
 	ereturn hidden scalar setcount = `setcount'
-
 	forvalues x = 1/`setcount' {
-	
 		fvunab set`x': `set`x''
-
 		ereturn local set`x' "`set`x''"
-		
-	}
-	
+	}	
 }
-
 else ereturn hidden scalar setcount = 0
-
-**# Ereturn macros
+	// ~~ title and options records ~~
 ereturn hidden local disp_title "`title'"
-
 ereturn hidden local reverse "`reverse'"
-
 if `:list sizeof all' {
-
 	fvunab all: `all'
-
 	ereturn local all "`all'"
-	
 }
-
 if strlen("`epsilon'") ereturn local estimate "epsilon" 
-
 else ereturn local estimate "dominance"
-
 if strlen("`regopts'") ereturn local regopts `"`regopts'"'
-
 ereturn local reg `"`reg'"'
-
 ereturn local fitstat "`fitstat'"
-
 ereturn local cmd `"domin"'
-
+ereturn local estat_cmd "domin_estat"
 ereturn local title `"Dominance analysis"'
-
 ereturn local cmdline `"domin `0'"'
-
-**# Ereturn matrices
+	// ~~ complete dominance ~~
 if !strlen("`complete'") {
 	matrix `cptdom' =  r(cptdom)
 	mata: st_matrixcolstripe("`cptdom'", ///
-		(J(cols(st_matrix("`cptdom'")), 1, "dominated?"), ///
-		st_matrixcolstripe("e(b)")[,2]))
+		(J(cols(st_matrix("`cptdom'")), 1, ""), ///
+		">":+st_matrixcolstripe("e(b)")[,2]))
 	mata: st_matrixrowstripe("`cptdom'", ///
-		(J(cols(st_matrix("`cptdom'")), 1, "dominates?"), ///
-		st_matrixcolstripe("e(b)")[,2]))
+		(J(cols(st_matrix("`cptdom'")), 1, ""), ///
+		st_matrixcolstripe("e(b)")[,2]:+">"))
 	ereturn matrix cptdom = `cptdom'
 }
-
+	// ~~ conditional dominance ~~
 if !strlen("`conditional'") {
 	matrix `cdldom' = r(cdldom)
 	mata: st_matrixcolstripe("`cdldom'", ///
-		(J(cols(st_matrix("`cdldom'")), 1, "#indepvars"), ///
+		(J(cols(st_matrix("`cdldom'")), 1, "include_at"), ///
 		strofreal(1::cols(st_matrix("`cdldom'")))))
 	ereturn matrix cdldom = `cdldom'
 }
-
+	// ~~ general dominance ranks and standardized values ~~
 matrix `ranks' = r(ranks)
 ereturn matrix ranking = `ranks'
-
 matrix `stdzd' = r(stdzd)
 ereturn matrix std = `stdzd'
-
+// ~~~ display or replay results ~~~
 Display
-
 end
-
-/*Display program*/
+**# Display program
 program define Display
-
 version 16
-
 tempname domwgts sdomwgts ranks
-
 matrix `domwgts' = e(b)
-
 matrix `sdomwgts' = e(std)
-
 matrix `ranks' = e(ranking)
-
 local diivs: colnames e(b)
-
 mata: st_local("cdltest", strofreal(cols(st_matrix("e(cdldom)"))))
-
 mata: st_local("cpttest", strofreal(cols(st_matrix("e(cptdom)"))))
-
 tokenize `diivs'
-
 local dv = abbrev("`e(depvar)'", 10)
-
-display _newline "{txt}General dominance statistics: `e(disp_title)'" _newline ///
-"{txt}Number of obs{col 27}={res}{col 40}" %12.0f e(N) 
-
+display _newline "{txt}General dominance statistics: `e(disp_title)'" ///
+	_newline "{txt}Number of obs{col 27}={res}{col 40}" %12.0f e(N) 
 display "{txt}Overall Fit Statistic{col 27}={res}{col 36}" %16.4f e(fitstat_o)
-
-if !missing(e(fitstat_a)) display "{txt}All Sub-models Fit Stat.{col 27}={res}{col 36}" %16.4f e(fitstat_a)
-
-if !missing(e(fitstat_c)) display "{txt}Constant-only Fit Stat.{col 27}={res}{col 36}" %16.4f e(fitstat_c)
-
-display _newline "{txt}{col 13}{c |}{col 20}Dominance{col 35}Standardized{col 53}Ranking"
-
+if !missing(e(fitstat_a)) display ///
+	"{txt}All Sub-models Fit Stat.{col 27}={res}{col 36}" %16.4f e(fitstat_a)
+if !missing(e(fitstat_c)) display ///
+	"{txt}Constant-only Fit Stat.{col 27}={res}{col 36}" %16.4f e(fitstat_c)
+display _newline ///
+	"{txt}{col 13}{c |}{col 20}Dominance{col 35}Standardized{col 53}Ranking"
 display "{txt}{lalign 9: `dv'}{col 13}{c |}{col 20}Stat.{col 35}Domin. Stat." 
-
 display "{txt}{hline 12}{c +}{hline 72}"
-
 forvalues x = 1/`:list sizeof diivs' {
-
 	local `x' = abbrev("``x''", 10)
-	
-	display "{txt}{col 2}{lalign 11:``x''}{c |}{col 14}{res}" %15.4f `domwgts'[1,`x'] ///
-	"{col 29}" %12.4f `sdomwgts'[1,`x'] "{col 53}" %-2.0f `ranks'[1,`x']
-	
+	display "{txt}{col 2}{lalign 11:``x''}{c |}{col 14}{res}" ///
+		%15.4f `domwgts'[1,`x'] "{col 29}" %12.4f `sdomwgts'[1,`x'] ///
+		"{col 53}" %-2.0f `ranks'[1,`x']
 }
-
 display "{txt}{hline 12}{c BT}{hline 72}"
-
 if `cdltest' {
-
 	display "{txt}Conditional dominance statistics" _newline "{hline 85}"
-	
 	matrix list e(cdldom), noheader format(%12.4f)
-	
 	display "{txt}{hline 85}"
-	
 }
-
 if `cpttest' {
-
-	display "{txt}Complete dominance designation" _newline "{hline 85}"
-	
+	display "{txt}Complete dominance proportions" _newline "{hline 85}"
 	matrix list e(cptdom), noheader
-	
 	display "{txt}{hline 85}"
-	
 }
-
 if e(estimate) == "dominance" & `=`cpttest'*`cdltest'' {
-
 	display _newline "{txt}Strongest dominance designations" _newline 
-
 	tempname bestdom cdl gen decision
-	
-	if strlen("`e(reverse)'") mata: st_matrix("`bestdom'", st_matrix("e(cptdom)"):*-1)
-	
+	if strlen("`e(reverse)'") mata: ///
+		st_matrix("`bestdom'", 1:-st_matrix("e(cptdom)"))
 	else matrix `bestdom' = e(cptdom)
-	
 	forvalues x = 1/`=colsof(e(cdldom))-1' {
-	
 		forvalues y = `=`x'+1'/`=colsof(e(cdldom))' {
-		
 			scalar `cdl' = 0
-			
 			scalar `gen' = 0
-	
 			mata: st_numscalar("`cdl'", (sum(st_matrix("e(cdldom)")[`x', .]:>st_matrix("e(cdldom)")[`y', .])):==rows(st_matrix("e(cdldom)"))) 
-			
 			if !`cdl' mata: st_numscalar("`cdl'", -1*((sum(st_matrix("e(cdldom)")[`x', .]:<st_matrix("e(cdldom)")[`y', .])):==rows(st_matrix("e(cdldom)"))))
-			
 			mata: st_numscalar("`gen'", st_matrix("e(b)")[1, `x']>st_matrix("e(b)")[1, `y'])
-			
 			if !`gen' mata: st_numscalar("`gen'", (st_matrix("e(b)")[1, `x']<st_matrix("e(b)")[1, `y'])*-1)
-			
-			local reverse_adj = cond(strlen("`e(reverse)'"), -1, 1)
-			
+			local reverse_adj = cond(strlen("`e(reverse)'"), 0, 1)
 			scalar `decision' = ///
-			cond(abs(`bestdom'[`x', `y']) == 1, `bestdom'[`x', `y'], cond(abs(`cdl') == 1, `cdl'*2, cond(abs(`gen') == 1, `gen'*3, 0)))
-			
+				cond(abs(`bestdom'[`x', `y']) == 1, `bestdom'[`x', `y'], cond(abs(`cdl') == 1, `cdl'*2, cond(abs(`gen') == 1, `gen'*3, 0)))
 			matrix `bestdom'[`x', `y'] = `decision'*`reverse_adj'
-			
 			matrix `bestdom'[`y', `x'] = -`decision'*`reverse_adj'
-			
 		}
-	
 	}
-	
 	local names `:colnames e(b)'
-	
 	mata: display(("{txt}", select(vec(tokens(st_local("names"))':+((st_matrix("`bestdom'"):==1):*" completely dominates "):+tokens(st_local("names")))', ///
 		regexm(vec(tokens(st_local("names"))':+((st_matrix("`bestdom'"):==1):*" completely dominates "):+tokens(st_local("names")))', ///
 		"completely dominates")) , ///
@@ -243,199 +183,148 @@ if e(estimate) == "dominance" & `=`cpttest'*`cdltest'' {
 		select(vec(tokens(st_local("names"))':+((st_matrix("`bestdom'"):==3):*" generally dominates "):+tokens(st_local("names")))', ///
 		regexm(vec(tokens(st_local("names"))':+((st_matrix("`bestdom'"):==3):*" generally dominates "):+tokens(st_local("names")))', ///
 		"generally dominates")))')
-	
 	display ""
-
 }
-
 if `=e(setcount)' {
-
 	forvalues x = 1/`=e(setcount)' {
-
 		display "{txt}Variables in set`x': `e(set`x')'"
-		
 	}
-	
 }
-
 if strlen("`e(all)'") display "{txt}Variables included in all sub-models: `e(all)'"
-
 end
-
 **# Mata function adapting Stata input for Mata and initiating the Mata environment
 version 16
 mata:
 mata set matastrict on
-void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, string scalar all, string scalar conditional, string scalar complete, string scalar epsilon, string scalar consmodel, string scalar reverse, string scalar esampleok, string scalar weight, string scalar inif, string scalar varlist) {
-/* ~ declarations and initial structure */
+void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, 
+	string scalar all, string scalar conditional, string scalar complete, 
+	string scalar epsilon, string scalar consmodel, string scalar reverse, 
+	string scalar esampleok, string scalar weight, string scalar inif, 
+	string scalar varlist) {
+/* ~~~ Mata object declarations ~~~ */
 	class AssociativeArray scalar model_specs
-	real scalar builtin, iv, set, rc, obs, full_fitstat, all_fitstat, cons_fitstat, index_count
+	real scalar builtin, iv, set, rc, obs, full_fitstat, all_fitstat, 
+		cons_fitstat, index_count
 	string scalar regopts, dv, marks
-	string rowvector ivs, iv_sets, bltin_varlist, bltin_index, bltin_all_varlist, bltin_all_index
+	string rowvector ivs, iv_sets, bltin_varlist, bltin_index, 
+		bltin_all_varlist, bltin_all_index
 	real rowvector bltin_dvcor
 	real matrix bltin_corrmat
 	transmorphic parser
-/* ~ argument checks ~ */
-	/*-domin- defaults*/
+/* ~~~ argument checks and defaults ~~~ */
+	/* ~~ assume built-in if empty reg() and fitstat() ~~ */
 	if ((!strlen(reg) & !strlen(fitstat)) & !strlen(epsilon)) {
 		reg = "regress"
 		fitstat = "e(r2)" 
-		weight = subinword( subinword( weight, "pweight", "aweight"), "iweight", "aweight")
+		weight = subinword(
+			subinword(weight, "pweight", "aweight"), "iweight", "aweight")
 		builtin = 1
 		if (strlen(consmodel)) {
-			display("{err}{opt consmodel} is not valid with built-in method.")
+			display("{err}{opt consmodel} is not allowed with " + 
+			"built-in linear regression method.")
 			exit(198)
 		}
 	} else if ( (strlen(reg) & strlen(fitstat)) | strlen(epsilon) ) {
 		builtin = 0
 	} else {
-		display("{err}Both {opt reg()} and {opt fitstat()} must be chosen or neither as of {cmd:domin} version 3.5.")
+		display("{err}Both or neither {opt reg()} and {opt fitstat()} must " + 
+		"be filled in as of {cmd:domin} version 3.5.")
 		exit(198)
 	}
-	/*'epsilon' specifics*/
+	/* ~~ 'epsilon' argument checks ~~*/
 	if ( strlen(epsilon) ) {
-		
-		/*exit conditions: user must restructure*/
 		if ( strlen(all + sets) ) { 									
-			
 			display("{err}{opt epsilon} not allowed with" + 
 					" {opt all()} or {opt sets()}.")
-			exit(198) 															
-				
+			exit(198) 																
 		}
-		
 	}	
-	
 /* ~ process iv and sets ~ */
 	/*parse varlist - store as 'ivs'*/
 	ivs = tokens(varlist)
-	
 	/*'dv ivs' structure means first entry is 'dv'*/
 	dv = ivs[1]
-	
 	/*remaining entries, if any, are 'ivs'*/
 	if ( length(ivs) > 1 ) ivs = ivs[2..length(ivs)]							
 	else ivs = ""
-	
 	/*set processing*/
 	if ( strlen(sets) ) {
 		/*setup parsing sets - bind on parentheses*/
 		parser = tokeninit(" ", "", "()")
 		tokenset(parser, sets)
-		
 		/*get all sets and remove parentehses*/
 		iv_sets = tokengetall(parser)
 		iv_sets = substr(iv_sets, 2, strlen(iv_sets):-2)
 		st_local("setcount", strofreal( length(iv_sets) ))
 		for (set=1; set<=length(iv_sets); set++) {
-			
 			st_local("set"+strofreal(set), iv_sets[set])
-			
 			rc = _stata("fvunab waste: " + iv_sets[set], 1)
-			if ( rc ) {
-				display("{err}Problem with variables in set position " + strofreal(set) + ": " + iv_sets[set])
+			if (rc) {
+				display("{err}Problem with variables in set position " + 
+				strofreal(set) + ": " + iv_sets[set])
 				exit(111)
 			}
-			
 		}
-		
 		/*combine to single iv vector*/
-		if ( length(ivs) > 0 ) ivs = (ivs, iv_sets)
+		if ( length(ivs) > 0 & ivs != "") ivs = (ivs, iv_sets)
 		else ivs = iv_sets
-	
 	}
-	
-	if ( length(ivs) < 2 | ivs == "") {	
-
+	if (length(ivs) < 2 | ivs == "") {	
 		stata("display " + char(34) + 
-			"{err}{cmd:domin} requires at least 2 independent variables or independent variable sets." + 
-			char(34))
+			"{err}{cmd:domin} requires at least 2 independent variables " + 
+			"or independent variable sets." + char(34))
 		exit(198)
-		
 	}
-
 /* ~ parse regression options ~ */
 	parser = tokeninit(" ", ",")
-	
 	tokenset(parser, strtrim(reg))
-	
 	reg = tokenget(parser)
-	
-	if ( length(tokenrest(parser)) ) regopts = substr(tokenrest(parser), 2)
+	if (length(tokenrest(parser))) regopts = substr(tokenrest(parser), 2)
 	else regopts = ""
-	
 /* ~ check primary analysis and set estimation sample ~ */
-	if ( !strlen(epsilon) ) {
-		
+	if (!strlen(epsilon)) {
 		st_eclear()
-		
 		if (inif == " ") inif = "if _n > 0"
-		
 		rc = _stata(reg + " " + dv + " " + invtokens(ivs) + " " + all +  
 			" [" + weight + "] " + inif + ", " + regopts, 1)
-		
-		if ( rc ) {
-			
+		if (rc) {
 			display("{err}{cmd:" + reg + "} resulted in an error.")
 			exit(rc)
-
 		}
-		
-		if ( !length( st_numscalar( strtrim(fitstat) ) ) )	{
-		
+		if (!length( st_numscalar( strtrim(fitstat))))	{
 			display("{err}{cmd:" + fitstat + 
 				"} not returned by {cmd:" + reg + "} or {cmd:" + fitstat + 
 				"} is not scalar valued. See {help return list}.")
 			exit(198)
-
 		}
-		else full_fitstat = st_numscalar( strtrim(fitstat) ) 
-		
+		else full_fitstat = st_numscalar(strtrim(fitstat)) 
 		marks = st_tempname()
-		
 		stata("generate byte " + marks[1] + " = e(sample)", 1)
-		
 		if (strmatch(weight, "fweight*") | strmatch(weight, "iweight*")) {
-		
-		stata("summarize " + marks[1] + " if " + marks[1] + 
-			" [" + weight + "]", 1)
-		
+			stata("summarize " + marks[1] + " if " + marks[1] + 
+				" [" + weight + "]", 1)
 		}
 		else stata("count if " + marks[1], 1)
-		
 		obs = st_numscalar("r(N)")
-	
 	}
 	else obs = 0
-
 	if (obs == 0 & strlen(esampleok) ) 	{
-	
 		marks = st_tempname(2)
-
 		stata("mark " + marks[1]) 
-		
 		stata("generate byte " + marks[2] + " = 1 " + inif, 1)
-			
 		stata("markout " + marks[1] + " " + marks[2] + 
 			" " + invtokens(ivs) + " " + all, 1)
-			
 		if (strmatch(weight, "fweight*") | strmatch(weight, "iweight*")) {
-		
-		stata("summarize " + marks[1] + " if " + marks[1] + 
-			" [" + weight + "]", 1)
-		
+			stata("summarize " + marks[1] + " if " + marks[1] + 
+				" [" + weight + "]", 1)
 		}
 		else stata("count if " + marks[1], 1)
-			
 		obs = st_numscalar("r(N)")
-	
 	}
-	
 	if (obs == 0 & !strlen(esampleok)) {
-		
-		display("{err}{cmd:esample()} not set. Use {opt noesampleok} to avoid checking {cmd:esample()}.")
+		display("{err}{cmd:esample()} not set. Use {opt noesampleok} to " + 
+			"avoid checking {cmd:esample()}.")
 		exit(198)
-		
 	}
 /* ~ built-in linear regression-based model ~ */
 	if (builtin) { 
@@ -480,18 +369,27 @@ void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, s
 		if (regexm(weight, "^[pi]weight=")) {
 			weight = regexr(weight, "^[pi]weight=", "aweight=")
 		}
-		stata("correlate " + invtokens(bltin_varlist) + " " + invtokens(bltin_all_varlist) + " [" + weight + "] if " + marks[1], 1)
+		stata("correlate " + invtokens(bltin_varlist) + " " + 
+			invtokens(bltin_all_varlist) + " [" + weight + "] if " + 
+			marks[1], 1)
 		bltin_corrmat = st_matrix("r(C)")
-		stata("correlate " + dv + " " + invtokens(bltin_varlist) + " " + invtokens(bltin_all_varlist) + " [" + weight + "] if " + marks[1], 1)
+		stata("correlate " + dv + " " + invtokens(bltin_varlist) + " " + 
+			invtokens(bltin_all_varlist) + " [" + weight + "] if " + 
+			marks[1], 1)
 		bltin_dvcor = st_matrix("r(C)")[1, 2..index_count]
 	}
 /* ~ begin collecting effect sizes ~ */
 	all_fitstat = 0
 	if (strlen(all) & !builtin) {
-		stata(reg + " " + dv + " " + all + " [" + weight + "] if " + marks[1] + ", " + regopts, 1)
+		stata(reg + " " + dv + " " + all + " [" + weight + "] if " + 
+			marks[1] + ", " + regopts, 1)
 		all_fitstat = st_numscalar(strtrim(fitstat))
 	} else if (strlen(all) & builtin) {
-		all_fitstat = bltin_dvcor[strtoreal(bltin_all_index)]*qrsolve(bltin_corrmat[strtoreal(bltin_all_index), strtoreal(bltin_all_index)], bltin_dvcor[strtoreal(bltin_all_index)]') // compute -all()- option's fitstat with built-in
+		all_fitstat = 
+			bltin_dvcor[strtoreal(bltin_all_index)]*qrsolve(
+				bltin_corrmat[strtoreal(bltin_all_index), 
+				strtoreal(bltin_all_index)], 
+				bltin_dvcor[strtoreal(bltin_all_index)]') // compute -all()- option's fitstat with built-in
 	}
 	cons_fitstat = 0
 	if (strlen(consmodel)) {	
@@ -505,9 +403,12 @@ void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, s
 /* ~ invoke dominance ~ */	
 	if (strlen(epsilon)) {
 		if (reg == "mvdom") {
-			stata("mvdom " + dv + " " + invtokens(ivs) + " if " + marks[1] + ", " + regopts + " epsilon", 1)
+			stata("mvdom " + dv + " " + invtokens(ivs) + " if " + 
+				marks[1] + ", " + regopts + " epsilon", 1)
 		} else {
-			eps_ri(dv + " " + invtokens(ivs), reg, marks[1], regopts, ( length(tokens(weight, "=")) == 3 ) ? tokens(weight, "=")[3] : "")
+			eps_ri(dv + " " + invtokens(ivs), reg, marks[1], regopts, 
+				(length(tokens(weight, "=")) == 3) ? 
+				tokens(weight, "=")[3] : "")
 		}
 	} else if (builtin) {
 		model_specs.put("corrmat", bltin_corrmat)
@@ -515,7 +416,8 @@ void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, s
 		model_specs.put("all", bltin_all_index)
 		model_specs.put("all_fitstat", all_fitstat)
 		model_specs.put("cons_fitstat", 0)
-		dominance(model_specs, &domin_regress(), bltin_index', conditional, complete, full_fitstat)	
+		dominance(model_specs, &domin_regress(), bltin_index', 
+					conditional, complete, full_fitstat)	
 	} else {
 		model_specs.put("reg", reg)
 		model_specs.put("fitstat", fitstat)
@@ -528,212 +430,148 @@ void domin_2mata(string scalar reg, string scalar fitstat, string scalar sets, s
 		model_specs.put("reverse", reverse)
 		model_specs.put("all_fitstat", all_fitstat)
 		model_specs.put("cons_fitstat", cons_fitstat)
-		dominance(model_specs, &domin_call(), ivs', conditional, complete, full_fitstat)	
+		dominance(model_specs, &domin_call(), ivs', 
+					conditional, complete, full_fitstat)
 	}
 /* ~ return values ~ */	
-	if ( length(iv_sets) )
-		ivs[(( length(ivs)-length(iv_sets)+1 )..length(ivs))] = 
-			"set":+( strofreal( (1..length(iv_sets)) ) )
-	
-	st_matrixcolstripe("r(domwgts)", (J(length(ivs), 1, ""), ivs') )
-	
-	if ( strlen(reverse) )
+	if (length(iv_sets))
+		ivs[((length(ivs)-length(iv_sets)+1 )..length(ivs))] = 
+			"set":+(strofreal((1..length(iv_sets))))
+	st_matrixcolstripe("r(domwgts)", (J(length(ivs), 1, ""), ivs'))
+	if (strlen(reverse))
+		st_matrix("r(cptdom)", 1:-st_matrix("r(cptdom)"))
+	if (!strlen(conditional)) 
+		st_matrixrowstripe("r(cdldom)", (J(length(ivs), 1, ""), ivs') )
+	if (!strlen(complete)) {
+		st_matrixrowstripe("r(cptdom)", (J(length(ivs), 1, ""), ivs'))
+		st_matrixcolstripe("r(cptdom)", (J(length(ivs), 1, ""), ivs'))
 		st_matrix("r(cptdom)", 
-			 st_matrix("r(cptdom)"):*-1 )
-	
-	if ( !strlen(conditional) ) st_matrixrowstripe("r(cdldom)", (J(length(ivs), 1, ""), ivs') )
-	
-	if ( !strlen(complete) ) {
-		st_matrixrowstripe("r(cptdom)", (J(length(ivs), 1, ""), ivs') )
-		st_matrixcolstripe("r(cptdom)", (J(length(ivs), 1, ""), ivs') )
+			st_matrix("r(cptdom)"):*editvalue(
+				!I(cols(st_matrix("r(cptdom)"))), 0, .))
 	}
-			
 	st_matrix("r(stdzd)", 
-		(st_matrix("r(domwgts)")):/(sum(st_matrix("r(domwgts)") ) ) ) 
-	st_matrixcolstripe("r(stdzd)", (J(length(ivs), 1, ""), ivs') )
-			
+		(st_matrix("r(domwgts)")):/(sum(st_matrix("r(domwgts)")))) 
+	st_matrixcolstripe("r(stdzd)", (J(length(ivs), 1, ""), ivs'))
 	st_matrix("r(ranks)", 
 		colsum( 
 			J(cols(st_matrix("r(domwgts)")), 
-				1, st_matrix("r(domwgts)") ):<=(st_matrix("r(domwgts)")') 
-			) )
-	if ( strlen(reverse) ) 
+				1, st_matrix("r(domwgts)") ):<=(st_matrix("r(domwgts)")')))
+	if (strlen(reverse)) 
 		st_matrix("r(ranks)", 
 			colsum( 
 				J(cols(st_matrix("r(domwgts)")), 
-					1, st_matrix("r(domwgts)") ):>=(st_matrix("r(domwgts)")') 
-				) )
-	st_matrixcolstripe("r(ranks)", (J(length(ivs), 1, ""), ivs') )
-		
+					1, st_matrix("r(domwgts)")):>=(st_matrix("r(domwgts)")')))
+	st_matrixcolstripe("r(ranks)", (J(length(ivs), 1, ""), ivs'))
 	st_numscalar("r(N)", obs)
-		
 	st_local("reg", reg)
 	st_local("regopts", regopts)
 	st_local("touse", marks[1])
 	st_local("dv", dv)
-	
 	st_numscalar("r(allfs)", all_fitstat)
 	st_numscalar("r(consfs)", cons_fitstat)
 	st_numscalar("r(fullfs)", full_fitstat)
-	
 }
-
 end
-
 **# Mata function to execute 'domin-flavored' models
 version 16
-
 mata:
-
 	mata set matastrict on
-
 	real scalar domin_call(string scalar IVs_in_model,
 		class AssociativeArray scalar model_specs) { 
-
 		real scalar fitstat
-
 		stata(model_specs.get("reg") + " " + model_specs.get("dv") + " " + 
 			model_specs.get("all") + " " + IVs_in_model + " [" + 
 			model_specs.get("weight") + "] if " + 
 			model_specs.get("touse") + ", " + model_specs.get("regopts"), 1)
-
-		fitstat = st_numscalar(model_specs.get("fitstat")) - 
+		fitstat = 
+			st_numscalar(model_specs.get("fitstat")) - 
 			model_specs.get("all_fitstat") - 
 			model_specs.get("cons_fitstat")
-
 		return(fitstat)
-
 	}
-	
 end
 **# Mata function to execute built-in linear regression
 version 16
 mata:
 mata set matastrict on
-real scalar domin_regress(string scalar IVs_in_model, class AssociativeArray scalar model_specs) { 
+real scalar domin_regress(string scalar IVs_in_model, 
+	class AssociativeArray scalar model_specs) { 
 	real scalar fitstat
 	real rowvector index
 	real colvector coeffs
 	real matrix analysis_mat
-	index = strtoreal(tokens(invtokens((IVs_in_model, model_specs.get("all")))))
-	coeffs = qrsolve(model_specs.get("corrmat")[index, index], model_specs.get("dvcor")[index]')
-	fitstat = model_specs.get("dvcor")[index]*coeffs - model_specs.get("all_fitstat")
+	index = 
+		strtoreal(tokens(invtokens((IVs_in_model, model_specs.get("all")))))
+	coeffs = 
+		qrsolve(model_specs.get("corrmat")[index, index], 
+		model_specs.get("dvcor")[index]')
+	fitstat = 
+		model_specs.get("dvcor")[index]*coeffs - model_specs.get("all_fitstat")
 	return(fitstat)
 }
 end
 **# Mata function to execute epsilon-based relative importance
-version 12
-
+version 16
 mata: 
-
 mata set matastrict on
-
 void eps_ri(string scalar varlist, string scalar reg, 
 	string scalar touse, string scalar regopts, string scalar weight) 
 {
 	/*object declarations*/
 	real scalar rc
-	
 	real matrix X, L, R, Lm, L2, R2, orth
-
 	real rowvector V, Bt, V2, glmwgts, varloc
-	
 	string rowvector orthnames
-	
 	real scalar sd_yhat, cor_yhat
-	
 	string scalar predmu, wgt_stmnt
-	
 	transmorphic view, wgt_view, mu_view
-	
 	/*begin processing*/
 	st_view(view, ., tokens(varlist), st_varindex(touse))
-	
 	if ( strlen(weight) ) st_view(wgt_view, ., weight, st_varindex(touse))
 	else wgt_view = 1
-	
 	X = correlation(view, wgt_view) //obtain correlations
-	
 	L = R = X[2..rows(X), 2..cols(X)] //set-up for svd()
-	
 	V = J(1, cols(X)-1, .) //placeholder for eigenvalues
-	
 	svd(X[2..rows(X), 2..cols(X)], L, V, R) //conduct singular value decomposition
-	
 	Lm = (L*diag( sqrt(V) )*R) //process orthogonalized predictors
-	
 	if (reg == "regress") Bt = invsym(Lm)*X[2..rows(X), 1] //obtain adjusted regression weights
-	
 	else if (reg == "glm") { //if glm-based...
-	
 		svd(
 			( view[., 2..cols(view)]:-mean( 
 				view[., 2..cols(view)] ) ):/( sqrt( diagonal( variance( 
 					view[., 2..cols(view)] ) ) )' ),
 		L2, V2, R2)
-		
 		orth = L2*R2 //produce the re-constructed orthogonal predictors for use in regression
-		
 		orth = (orth:-mean(orth)):/sqrt( diagonal( variance(orth) ) )' //standardize the orthogonal predictors
-		
 		orthnames = st_tempname( cols(orth) )
-		
 		varloc = st_addvar("double", orthnames) //generate some tempvars for Stata
-		
 		st_store(., orthnames, st_varindex(touse), orth) //put the orthogonalized variables in Stata
-		
 		if ( strlen(weight) ) wgt_stmnt = " [iweight="
 		else wgt_stmnt = " ["
-		
 		rc = _stata("glm " + tokens(varlist)[1] + " " + 
 			invtokens(orthnames) + wgt_stmnt + weight + "] if " + 
 			touse + ", " + regopts, 1) //conduct the analysis
-
 		if ( rc ) {
-		
 			display("{err}{cmd:" + reg + "} failed when executing {cmd:epsilon}.")
-		
 			exit( rc )
-			
 		}
-		
 		glmwgts = st_matrix("e(b)") //record the regression weights to standardize
-		
 		predmu = st_tempname() //generate some more tempvars for Stata
-		
 		sd_yhat = sqrt( variance(orth*glmwgts[1, 1..cols(glmwgts)-1]') ) //SD of linear predictor
-		
 		stata("predict double " + predmu + " if " + touse + ", mu", 1) //translated with link function
-		
 		st_view(mu_view, ., st_varindex(predmu), st_varindex(touse))
-		
 		cor_yhat = correlation((view[., 1], mu_view), wgt_view)
-		
 		Bt = (glmwgts[1, 1..cols(glmwgts)-1]:*((cor_yhat[2, 1])/(sd_yhat)))'
-
 	}
-	
 	else { //asked for invalid reg
-	
 		display("{err}{opt reg(" + reg + ")} invalid with {opt epsilon}.")
-	
 		exit(198)
-		
 	}
-	
 	Bt = Bt:^2 //square values of regression weights
-	
 	Lm = Lm:^2 //square values of orthogonalized predictors
-
 	st_matrix("r(domwgts)", (Lm*Bt)')	//produce proportion of variance explained and put into Stata
-	
 }
-
 end
-
-/* programming notes and history
-- domin_se version 0.0.0 - date - mth day, year
-
 
 /* programming notes and history
 - domin version 1.0 - date - April 4, 2013
@@ -826,14 +664,10 @@ end
  - -mi_dom- and factor- and time-series variable error fixes (thanks to katherine // kathy chan)
  // 3.5.3 - December 20, 2024
  -  version of all programs at a minimum to 16 to accommodate the use of usrsplit() which is not available before v 16
- -  fixed error in checking number of IVs with a combinatoin of IVs and IV sets when there was only one IV
+ -  fixed error in checking number of IVs with a combinatoin of IVs and IV sets when there was only one IV (thanks to Jurjen Iedema for error reporting)
  ---
- 
- future domin
- ** planned ** - commonality coefficients?
- ** planned ** - bootstrap?
- ** planned ** - built in -glm-?
- ** planned ** - depreciated by -domin2-'s bmaregress interface; eventually will be defunct and enveloped by its interface
- ** planned ** - owen decomp
- ** planned ** - mi with mixdom // mvdom (tor neilands)
- */
+ domin version 3.6.0 - May 5, 2025
+ - bugfix introduced in 3.5.3 when there are no regular IVs and two or more sets
+ - -mvdom- and -mixdom- compatable with -mi_dom- // thanks to Tor Neilands for the suggestion
+ - update complete dominance designations to complete dominance proportions
+ - update display on complete and conditional dominance matrices

--- a/domin.sthlp
+++ b/domin.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.5.3 December 20, 2024 J. N. Luchman}{...}
+{* *! version 3.6.0 May 5, 2025 J. N. Luchman}{...}
 {cmd:help domin}
 
 {title:Title}
@@ -589,18 +589,6 @@ reduce the bias of coefficient estimates and dominance statistics when the imput
 {p 4 8 2}Tonidandel, S., & LeBreton, J. M. (2010). Determining the relative importance of predictors in logistic regression: An extension of relative weight analysis. {it:Organizational Research Methods, 13(4)}, 767-781.{p_end}
 {p 4 8 2}Thomas, D. R., Zumbo, B. D., Kwan, E., & Schweitzer, L. (2014). On Johnson's (2000) relative weights method for assessing variable importance: A reanalysis. {it:Multivariate Behavioral Research, 49(4)}, 329-338.{p_end} 
 
-{title:Development Webpage}
-
-{phang} Additional discussion of results, options, and conceptual issues on: 
-
-{phang}{browse "https://github.com/fmg-jluchman/domin/wiki"}
-
-{phang} Please report bugs, requests for features, and contribute to as well as follow on-going development of {cmd:domin} on:
-
-{phang}{browse "http://github.com/fmg-jluchman/domin"}
-
-{title:Article}
-
 Please cite as:
 
 {p 4 8 2}Luchman, J. N. (2021). Determining relative importance in Stata using dominance analysis: domin and domme. {it:The Stata Journal, 21(2)}, 510–538. https://doi.org/10.1177/1536867X211025837{p_end}
@@ -620,13 +608,15 @@ Please cite as:
 {browse "https://ideas.repec.org/c/boc/bocode/s457543.html":shapley2}, 
 {browse "https://CRAN.R-project.org/package=domir":R package domir}, 
 {browse "https://CRAN.R-project.org/package=relaimpo":R package relaimpo},
-{browse "https://cran.r-project.org/web/packages/domir/vignettes/domir_basics.html": Detailed description of Dominance Analysis}
+{browse "https://cran.r-project.org/web/packages/domir/vignettes/domir_basics.html":Detailed description of Dominance Analysis}
+{browse "http://github.com/fmg-jluchman/domin":Webpage}
+{phang}{browse "https://github.com/fmg-jluchman/domin/wiki":Wiki}
 
 {title:Acknowledgements}
 
 {pstd}Thanks to Nick Cox, Ariel Linden, Amanda Yu, Torsten Neilands, Arlion N, 
 Eric Melse, De Liu, Patricia "Economics student", Annesa Flentje, Felix Bittman, 
-and Katherine/Kathy Chan for suggestions and bug reporting.
+Katherine/Kathy Chan, and Jurjen Iedema for suggestions and bug reporting.
 
 
 

--- a/dominance.mata
+++ b/dominance.mata
@@ -109,7 +109,7 @@ void dominance(
 	}
 	
 	fitstat_vector[1] = full_fitstat
-
+	
 	/*define the incremental prediction matrices and combination rules*/
 	IV_antiindicator_matrix = (IV_indicator_matrix:-1) //matrix flagging which IVs are not included in each model and setting them up for a subtractive effect
 	
@@ -168,7 +168,7 @@ void dominance(
 		for (x = 1; x <= comb(number_of_IVs, 2); x++) {  
 		
 			select2IVs = cvpermute(cpt_permute_container) //invoke 'cvpermute' on the container - selects a unique combination of two IVs
-		
+			
 			select2IVfits = colsum(select(IV_indicator_matrix, select2IVs)):==1 //filter IV indicator matrix to include just those fit statistic columns that inlude focal IVs - then only keep the columns that have one (never both or neither) of the IVs 
 		
 			focal_row_numbers = (1..rows(IV_indicator_matrix)) //sequence of numbers for selecting specific rows indicating focal IVs
@@ -184,18 +184,21 @@ void dominance(
 			compare_two_IVs = ///
 				(select(sorted_two_IVs[,cols(sorted_two_IVs)], mod(1::rows(sorted_two_IVs), 2)), /// //select the odd rows for comparison (see constuction of 'sorted_two_IVs')
 				select(sorted_two_IVs[,cols(sorted_two_IVs)], mod((1::rows(sorted_two_IVs)):+1, 2))) //select the even rows for comparison 
-			
-			cpt_desig = ///
+			/*cpt_desig = ///
 				(all(compare_two_IVs[,1]:>compare_two_IVs[,2]), /// //are all fit statistics in odd/first variable larger than the even/second variable?
 				all(compare_two_IVs[,1]:<compare_two_IVs[,2])) //are all fit statistics in even variable larger than the odd variable?
 			
 			if (cpt_desig[2] == 1) complete_dominance[focal_row_numbers[1], focal_row_numbers[2]] = 1 	//if the even/second variables' results are all larger, record "1"...
 				else if (cpt_desig[1] == 1) complete_dominance[focal_row_numbers[1], focal_row_numbers[2]] = -1 //else if the odd/first variables' results are all larger, record "-1"...
-					else complete_dominance[focal_row_numbers[1], focal_row_numbers[2]] = 0 //otherwise record "0"...
+					else complete_dominance[focal_row_numbers[1], focal_row_numbers[2]] = 0 //otherwise record "0"... */
+			cpt_desig = sum((compare_two_IVs[,1]:>compare_two_IVs[,2]):/rows(compare_two_IVs))
+			complete_dominance[focal_row_numbers[2], focal_row_numbers[1]] = cpt_desig
+			complete_dominance[focal_row_numbers[1], focal_row_numbers[2]] = 1 - cpt_desig
+				
 	
 		}
 		
-		complete_dominance = complete_dominance + complete_dominance'*-1 //make cptdom matrix symmetric
+		//complete_dominance = complete_dominance + complete_dominance'*-1 //make cptdom matrix symmetric
 	
 		st_matrix("r(cptdom)", complete_dominance) //return r-class matrix "cptdom"
 	

--- a/domme.ado
+++ b/domme.ado
@@ -1,25 +1,23 @@
-*! domme version 1.2.1 12/20/2024 Joseph N. Luchman
-// version information at end of file
+*! domme version 1.3.0 x/x/202x Joseph N. Luchman
 
 **# Pre-program definition
 quietly include dominance.mata, adopath
-
 program define domme, eclass 
-
-	version 16
-
-	if replay() & !strlen("`0'") {
-
-		if ("`e(cmd)'" != "domme") error 301
-
-		if _by() error 190
-
-		Display `0'
-
-		exit 0
-
-	}
-	
+if `c(version)' < 16 {
+	display "{err}As of {cmd:domme} version 1.2.1, the minimum version of " ///
+	"Stata is 16." _newline "If you have an older version of Stata, most " ///
+	"functionality of {cmd:domme} is available from" _newline ///
+	`"{stata net install st0645:this}"' ///
+	" Stata journal article back to version 15."
+	exit 198
+}
+version 16
+if replay() & !strlen("`0'") {
+	if ("`e(cmd)'" != "domme") error 301
+	if _by() error 190
+	Display `0'
+	exit 0
+}
 **# Program definition and argument checks
 syntax [anything(id="equation names" equalok)] [in] [if] [aw pw iw fw], ///
 	Reg(string) Fitstat(string) ///
@@ -67,23 +65,15 @@ else ereturn hidden scalar setcount = 0
 
 **# Ereturn macros
 ereturn hidden local disp_title "`title'"
-
 ereturn hidden local reverse "`reverse'"
-
 if strlen("allset") ereturn local all = "`allset'"
-
 if strlen("`ropts'") ereturn local ropts `"`ropts'"'
-
 ereturn local reg "`reg'"
-
 ereturn local fitstat "`fitstat'"
-
 ereturn local cmd "domme"
-
+ereturn local estat_cmd "domin_estat"
 ereturn local title `"Dominance analysis for multiple equations"'
-
 ereturn local cmdline `"domme `0'"'
-
 **# Ereturn matrices
 if !strlen("`conditional'") ereturn matrix cdldom `cdldom'
 
@@ -103,7 +93,7 @@ end
 /*Display program*/
 program define Display
 
-version 15
+version 16
 
 /*set up*/
 tempname gendom stzd_gendom ranks
@@ -170,7 +160,7 @@ if `cdltest' {
 
 if `cpttest' {	
 
-	display "{txt}Complete dominance designation" _newline "{hline 85}"
+	display "{txt}Complete dominance proportions" _newline "{hline 85}"
 
 	matrix list e(cptdom), noheader
 
@@ -268,7 +258,7 @@ if strlen("`e(all)'") ///
 end
 
 **# Mata function adapting Stata input for Mata and initiating the Mata environment
-version 15
+version 16
 
 mata:
 
@@ -660,12 +650,12 @@ void domme_2mata(
 	if ( !strlen(conditional) ) {
 		st_matrixrowstripe("r(cdldom)", (eq_display \ parm_display)' )
 		st_matrixcolstripe("r(cdldom)", 
-			(J(1, length(dv_iv_pairs), "#param_ests") \ strofreal(1..length(dv_iv_pairs)))' )
+			(J(1, length(dv_iv_pairs), "include_at") \ strofreal(1..length(dv_iv_pairs)))' )
 	}
 	
 	if ( !strlen(complete) ) {
-		st_matrixrowstripe("r(cptdom)", (">?":+eq_display \ parm_display)' )
-		st_matrixcolstripe("r(cptdom)", ("<?":+eq_display \ parm_display)' )
+		st_matrixrowstripe("r(cptdom)", (eq_display \ parm_display:+">")' )
+		st_matrixcolstripe("r(cptdom)", (">":+eq_display \ parm_display)' )
 	}
 	
 	st_matrix("r(stdzd)", 
@@ -705,7 +695,7 @@ void domme_2mata(
 end
 
 **# Mata function to execute 'domme-flavored' models
-version 15
+version 16
 
 mata:
 
@@ -759,60 +749,36 @@ mata:
 end
 
 **# Mata function to drop constraints and exit
-version 15
-
+version 16
 mata:
-
-	mata set matastrict on
-	
-	void exit_constraint(string rowvector cns_list, numeric scalar exit_num) {
-		
-		numeric scalar cns
-		
-		for (cns=1; cns<=length(cns_list); cns++) {
-			
-			stata("constraint drop " + cns_list[cns])
-			
-		}
-		
-		if (exit_num) exit(exit_num)
-		
+mata set matastrict on
+void exit_constraint(string rowvector cns_list, numeric scalar exit_num) 
+{
+	numeric scalar cns
+	for (cns=1; cns<=length(cns_list); cns++) {
+		stata("constraint drop " + cns_list[cns])		
 	}
-	
+	if (exit_num) exit(exit_num)		
+}
 end
-
 **# Mata program to obtain fit statistics after model estimation
-
-version 15
-
+version 16
 mata:
-
-	mata set matastrict on
-	
-	numeric scalar built_in_fitstat(
-		string scalar fitstat, string scalar type, numeric scalar constant, 
-		numeric scalar isconstant
-	) {
-		
-		numeric scalar value
-		
-		/*compute McFadden R2*/
-		if (type == "mcf") {
-			
-			value = (isconstant? 
-				st_numscalar("e(ll)") : 
-				1 - st_numscalar("e(ll)")/constant)
-			
-		}
-		/*not a built-in, pass the name and assume Stata returns it*/
-		else value = st_numscalar( strtrim(fitstat) ) 
-		
-		return(value)
-		
+mata set matastrict on
+numeric scalar built_in_fitstat(string scalar fitstat, string scalar type, 
+	numeric scalar constant, numeric scalar isconstant) 
+{
+	numeric scalar value
+	/*compute McFadden R2*/
+	if (type == "mcf") {
+		value = (isconstant? 
+		st_numscalar("e(ll)") : 1 - st_numscalar("e(ll)")/constant)
 	}
-
+	/*not a built-in, pass the name and assume Stata returns it*/
+	else value = st_numscalar( strtrim(fitstat) ) 
+	return(value)
+}
 end
-
 /* programming notes and history
    - domme version 1.0 - date - July 2, 2019
    -base version
@@ -841,6 +807,10 @@ end
  - estrella, aic and bic disallowed with built-in; mcfadden remains
  // 1.2.1 - December 20, 2024
  - version incremented to 16 consistent with base -domin-
- // 1.2.2 - ....
- ** planned  -- fixed parsing for outcomes to accommodate factor variables (gsem)
+ ---
+ domme version 1.3.0 - mth day, 202x
+ - update complete dominance designations to complete dominance proportions
+ - update display on complete and conditional dominance matrices
+ -- estats!
+ ** planned -- fix parsing for outcomes to accommodate factor variables (gsem)
 */

--- a/fitdom.ado
+++ b/fitdom.ado
@@ -1,28 +1,19 @@
 *! fitdom version 0.1.1  12/20/2024 Joseph N. Luchman
-
-program define fitdom, eclass //history and version information at end of file
-
+**# Program definition
+program define fitdom, eclass
 version 16
-
 syntax varlist(min = 1 ts fv) if [aw pw iw fw] , [Reg_fd(string) Postestimation(string) Fitstat_fd(string)]
-
+**# Parse varlist
 gettoken dv ivs: varlist	//parse varlist line to separate out dependent from independent variables
-
 gettoken reg regopts: reg_fd, parse(",")	//parse reg() option to pull out estimation command options
-
 if strlen("`regopts'") gettoken erase regopts: regopts, parse(",")	//parse out comma if one is present
-
-`reg' `dv' `ivs' [`weight'`exp'] `if', `regopts'	//conduct analysis without independent variables
-
+**# Implement estimation command
+`reg' `dv' `ivs' [`weight'`exp'] `if', `regopts'
+**# Postestimation command for estimation command
 `postestimation'
-
+**# Return values
 ereturn scalar fitstat = `=`fitstat_fd''
-
-//note to self needs title and esample <- how to work with non-esample commands?
-
 end
-
-
 /* programming notes and history
 - fitdom version 0.0.0 - Nov 21, 2021 
  ---

--- a/fitdom.sthlp
+++ b/fitdom.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 0.1.1 December 20, 2023 J. N. Luchman}{...}
+{* *! version 0.1.1 December 20, 2024 J. N. Luchman}{...}
 {cmd:help fitdom}
 {hline}{...}
 

--- a/mi_dom.ado
+++ b/mi_dom.ado
@@ -1,47 +1,32 @@
-*! mi_dom version 0.0.3  12/20/2024 Joseph N. Luchman
-
-program define mi_dom, eclass //history and version information at end of file
-
+*! mi_dom version 0.0.4 1/1/2025 Joseph N. Luchman
+**# Program definition
+program define mi_dom, eclass
 version 16
-
-syntax varlist(min = 1 fv ts) if [aw fw iw pw], Reg_mi(string) Fitstat_mi(string) [MIOpt(string)] 
-
+syntax varlist(min = 1 fv ts) [if] [aw fw iw pw], Reg_mi(string) Fitstat_mi(string) [MIOpt(string)] 
+**# Set Stata Environment
 tempfile mifile	//produce a tempfile to store imputed fitstats for retreival
-
 tempvar touse 
-
 tempname fitstat
-
-gettoken reg_mi regopts_mi: reg_mi // separate out reg() options
-
+**# Parse varlist and estimate 
+gettoken reg_mi regopts_mi: reg_mi, parse(",") // separate out reg() options
+local regopts_mi = regexr("`regopts_mi'", "^,", "") // remove leading comma for options when present
 quietly generate byte `touse' = 1 `if'
-
-quietly mi estimate, saving(`mifile') `miopt': `reg_mi' `varlist' [`weight'`exp'] `if', `regopts_mi'	//run mi analysis saving results
-
+**# Implement multiple imputaiton estimation command
+quietly mi estimate, saving(`mifile') `miopt': `reg_mi' `varlist' [`weight'`exp'] `if', `regopts_mi'	//run mi analysis while saving results
+**# 
 scalar `fitstat' = 0 //placeholder scalar to hold the sum
-
 local num_imputes = `:word count `e(m_est_mi)''
-
-foreach x of numlist `=e(m_est_mi)' {
-
-	estimates use `mifile', number(`x') //find the focal estimates
-	
-	scalar `fitstat' = `fitstat' + `=`fitstat_mi''*`num_imputes'^-1 //add in the weighted fitstat value
-
+foreach imputation of numlist `=e(m_est_mi)' {
+	estimates use `mifile', number(`imputation') //find the focal estimates
+	scalar `fitstat' = `fitstat' + `=`fitstat_mi''*`num_imputes'^(-1) //add in the weighted fitstat value
 }
-
+**# Return values
 local title = e(title)
-
 ereturn clear
-
-ereturn post, esample(`touse')
-
+ereturn post, esample(`touse') // note, assumption is all obs used that are not 'if'-ed out
 ereturn local title = "Multiply imputed: `title'"
-
 ereturn scalar fitstat = `fitstat'
-	
 end
-
 /* programming notes and history
 - mi_dom version 0.0.0 - August 14, 2023
 // 0.0.1 - January 12, 2024
@@ -49,5 +34,7 @@ end
 // 0.0.2 - August 13, 2024
  - allows factor- and time-series variables - thanks to katherine // kathy chan for bug report
  - fix to documentation of -reg_mi()- option
-// 0.0.3 -December 20, 2024
+// 0.0.3 - December 20, 2024
 -  version to 16 consistent with base -domin-
+// 0.0.4 - January 1, 2025
+- fix for options; not parsing on comma

--- a/mi_dom.sthlp
+++ b/mi_dom.sthlp
@@ -1,20 +1,20 @@
 {smcl}
-{* *! version 0.0.3 December 20, 2024 J. N. Luchman}{...}
+{* *! version 0.0.4 January 1, 2025 J. N. Luchman}{...}
 {cmd:help mi_dom}
 {hline}{...}
 
 {title:Title}
 
 {pstd}
-Wrapper program for {cmd:domin} to obtain multiply imputed fit statistics {p_end}
+Multiple imputation wrapper program for {cmd:domin} {p_end}
 
 {title:Syntax}
 
 {phang}
-{cmd:mi_dom} {it:depvar} {it:indepvars} {it:{help if} {weight}} {cmd:,} 
+{cmd:mi_dom} {it:depvar} {it:indepvars} {it:[{help if}] {weight}} {cmd:,} 
 {opt {ul on}r{ul off}eg_mi(command[, command_options])} 
 {opt {ul on}f{ul off}itstat_mi(scalar)}
-[{opt {ul on}MIO{ul off}pt(string)}]
+[{opt {ul on}mio{ul off}pt(mi_opts)}]
 
 {phang}
 {help fvvarlist: Factor} and {help tsvarlist:time series variables} are allowed for commands in {opt reg_mi()} 
@@ -24,27 +24,38 @@ that accept them. {cmd:aweight}, {cmd:iweight}s, {cmd:pweight}s, and {cmd:fweigh
 {title:Description}
 
 {pstd}
-{cmd:mi_dom} adds an additional layer to {cmd:domin} in which the user calls the {cmd:mi_dom} program in 
-{cmd:domin} and the {cmd:mi_dom} program runs the {cmd:mi estimate} compatible command in {opt reg_mi()}, 
-saves results for all multiply imputed datasets, and then averages them before submitting them as 
-{cmd:e(fitstat)} for use in the dominance analysis.
+{cmd:mi_dom} is a specialized {help mi estimate:multiple imputation} command that is designed for use in {help domin:dominance analysis}.
+{cmd:mi_dom} is an alternative to the {cmd:mi estimate} prefix for the dominance analysis of estimation commands that averages the fit statistics returned by individual imputations so that one submodel returns one fit statistic.
+For an example, see {cmd:domin}'s {help domin##examp:Example #10}.
 
 {pstd}
-This wrapper command is a replacement for the built in {opt mi} in {cmd:domin} versions prior to 3.5 and is 
-intended to add flexiblity to how {cmd:domin} can accommodate multiply imputed data. See Example #10 in the 
-{cmd:domin} helpfile for an example of {cmd:mi_dom} in use.
+{cmd:mi_dom} is intended to be called directly by {cmd:domin} and will act as an intermediary layer of processing between {cmd:domin} and the estimation command that will use {cmd:mi estimate}.
+Specifically, {cmd:mi_dom} will call the command in {opt reg_mi()} and average the results for the scalar in {opt fitstat_mi()} across all imputations.
+Thus, {cmd:mi_dom} is called directly in {cmd:domin}'s {opt reg()} option.
+{cmd:mi_dom}'s options are then also supplied to {cmd:domin} as command options in the {opt reg()} option.
+Addiiontally, the averaged fit staistic scalar {cmd:e(fitstat)} is called directly in {cmd:domin}'s {opt fitstat()} option.
+
+{pstd}
+{cmd:mi_dom} is intended for use only as a wrapper program with {cmd:domin} and is not recommended for use as an estimation command outside of {cmd:domin}.
+{cmd:mi_dom} is a replacement for the built in {opt mi} option for {cmd:domin} versions prior to 3.5.0.
 
 {marker options}{...}
 {title:Options}
 
-{phang}{opt reg_mi()} is the contents of the {opt reg()} option that would normally be supplied to {cmd:domin}.
+{phang}{opt reg_mi()} is the command and command options implementing the predictive model that will be applied to {cmd:mi estimate}.
+This option is parsed in the same way as the {opt reg()} option of {help domin##opts:domin}.
 
-{phang}{opt fitstat_mi()} is the contents of the {opt fitstat()} option that would normally be supplied 
-to {cmd:domin}.
+{phang}{opt fitstat_mi()} identifies the scalar returned by the command in {opt reg_mi()} that will be averaged.
+This option is usedd in the same way as the {opt fitstat()} option of {help domin##opts:domin}.
 
-{phang}{opt miopt()} are the options passed to {cmd:mi estimate} that will be filled in prior to the colon. 
-This produces a command structure like {it:mi estimate, miopts: reg_mi} for each run of the command in 
-{opt reg_mi()}.
+{phang}{opt miopt()} are options passed to {cmd:mi estimate}. 
+For example, the command:
+
+{pmore}{cmd:mi_dom depvar indepvars, miopt(mi_opts) reg_mi(command)} 
+
+{pmore}would be passed to {cmd:mi estimate} as:
+
+{pmore}{cmd:mi estimate, mi_opts: command depvar indepvars}
 
 {title:Saved results}
 
@@ -52,11 +63,11 @@ This produces a command structure like {it:mi estimate, miopts: reg_mi} for each
 
 {synoptset 16 tabbed}{...}
 {p2col 5 15 19 2: scalars}{p_end}
-{synopt:{cmd:e(fitstat)}}The value of the fit statistic called by {opt postestimation}{p_end}
+{synopt:{cmd:e(fitstat)}}The value of the averaged fit in {opt fitstat_mi()} across all imputations{p_end}
 {p2col 5 15 19 2: macros}{p_end}
 {synopt:{cmd:e(title)}}Adds "Mulltiply Imputed:" to the {cmd:e(title)} of the command in {opt reg_mi()}{p_end}
 {p2col 5 15 19 2: functions}{p_end}
-{synopt:{cmd:e(sample)}}marks estimation sample{p_end}
+{synopt:{cmd:e(sample)}}marks estimation sample; all missing observations on {it:depvar} and {it:indepvars} are assumed to be complete{p_end}
 
 {title:Author}
 

--- a/mixdom.ado
+++ b/mixdom.ado
@@ -1,112 +1,89 @@
-*! mixdom version 2.1.1 12/20/2024 Joseph N. Luchman
-
+*! mixdom version 2.2.0  12/26/2024 Joseph N. Luchman
+**# Program definition and initialization
 version 16
-
-program define mixdom, eclass
-
-syntax varlist(min = 2 fv ts) [pw fw] [if], id(varlist max = 1 min = 1) [REopt(string) XTMopt(string) ///
-Mopt(string)]
-
+program define mixdom, eclass properties(mi)
+syntax varlist(min = 2 fv ts) [pw fw] [if], id(varlist max = 1 min = 1) ///
+	[REopt(string) XTMopt(string) Mopt(string)]
+**# Error conditions
 if strlen("`xtmopt'")  {
     display as err "{cmd:xtmopt()} is defunct. Use {cmd:mopt()}."
 	exit 198
 }
-
-tempname estmat r2w r2b base_e base_u mean_h
-
+**# Environment set-up
+tempname estmat r2w r2b base_e base_u mean_h b V
 tempvar touse
-
-gettoken dv ivs: varlist
-
+	* ~~ check for pre-existing re-usable baseline estimates ~~ 
 foreach temp in base_e base_u mean_h {
-
 	capture assert e(`temp')
-
 	if !_rc scalar ``temp'' = e(`temp')
-
 }
-
-mixed `dv' `ivs' [`weight'`exp'] `if' , `constant' || `id':, `reopt' `mopt' nostderr
-
+**# Parse varlist and estimate 
+gettoken dv ivs: varlist
+mixed `dv' `ivs' [`weight'`exp'] `if', || `id':, `reopt' `mopt' nostderr
+**# Process estimates
 matrix `estmat' = e(b)
-
-scalar `r2w' = (exp(`estmat'[1, `=colsof(`estmat') - 1']))^2 + (exp(`estmat'[1, `=colsof(`estmat')']))^2
-
+scalar `r2w' = ///
+	(exp(`estmat'[1, `=colsof(`estmat') - 1']))^2 + ///
+	(exp(`estmat'[1, `=colsof(`estmat')']))^2
 if missing(`mean_h') {
-
 	preserve
-
 	quietly collapse (count) `dv' `if', by(`id') fast
-
 	quietly ameans `dv'
-
 	scalar `mean_h' = r(mean_h)
-	
-	di `mean_h'
-
 	restore
-
 }
-
-scalar `r2b' = (exp(`estmat'[1, `=colsof(`estmat') - 1']))^2 + ((exp(`estmat'[1, `=colsof(`estmat')']))^2)/`mean_h'
-
+scalar `r2b' = ///
+	(exp(`estmat'[1, `=colsof(`estmat') - 1']))^2 + ///
+	((exp(`estmat'[1, `=colsof(`estmat')']))^2)/`mean_h'
+**# Estimate baseline results if not available from previous run
 if missing(`base_e') | missing(`base_u') {
-
-	mixed `dv' [`weight'`exp'] `if' , `constant' || `id':, `reopt' `mopt' nostderr
-
+	mixed `dv' [`weight'`exp'] `if', || `id':, `reopt' `mopt' nostderr
 	matrix `estmat' = e(b)
-
 	scalar `base_e' = `estmat'[1, `=colsof(`estmat')']
-
 	scalar `base_u' = `estmat'[1, `=colsof(`estmat') - 1']
-	
 }
-
+**# Construct R2 metrics
 scalar `r2w' = 1 - ((exp(`base_u'))^2 + (exp(`base_e'))^2)^-1*`r2w'
-
-scalar `r2b' = 1 - ((exp(`base_u'))^2 + ((exp(`base_e'))^2)/`mean_h')^-1*`r2b'
-
+scalar `r2b' = 1 - ((exp(`base_u'))^2 + ((exp(`base_e'))^2)/`mean_h')^(-1)*`r2b'
+**# Return values
 generate `touse' =  e(sample)
-
 ereturn clear
-
-ereturn post, esample(`touse')
-
+	* ~~ 'dummy' values for -mi_dom- ~~ 
+matrix `b' = 1
+matrix colnames `b' = "empty"
+matrix `V' = 1
+matrix colnames `V' =  "empty"
+matrix rownames `V' =  "empty"
+ereturn post `b' `V', esample(`touse')
+	* ~~ return R2s ~~
 ereturn scalar r2_w = `r2w'
-
 ereturn scalar r2_b = `r2b'
-
-ereturn local title = "Mixed-effects ML regression"
-
-ereturn hidden scalar base_e = `base_e' // note to self - make these hidden not official returned values
-
+ereturn local cmd "mixdom"
+ereturn local title "Mixed-effects ML regression"
+	* ~~ re-usable baseline errors and harmonic sample size estimates ~~ 
+ereturn hidden scalar base_e = `base_e'
 ereturn hidden scalar base_u = `base_u'
-
 ereturn hidden scalar mean_h = `mean_h'
-
-// note to self - return esample and title
-
 end
-
 /* programming notes and history
-
-- mixdom version 1.0 - date - Jan 15, 2014
+- mixdom version 1.0 - date - January 15, 2014
 Basic version
 -----
-- mixdom version 1.1 - date - Mar 11, 2015
+- mixdom version 1.1 - date - March 11, 2015
 - added version statement (12.1)
 - time series operators allowed
 - removed scalars persisting after estimation
 -----
-- mixdom version 2.0 - date - Feb 15, 2021
+- mixdom version 2.0 - date - February 15, 2021
 - -xtmopt()- depreciated in favor of -mopt()-
  ---
- mixdom version 2.1.0 - mth day, year
+ mixdom version 2.1.0 - August 14, 2023
  - minimum version 15 consistent with base -domin-
  - xtmopt defunct - gives warning
  - noconstant option removed
  - returns e(smaple) to satisfy -domin- 3.5 requirements
  // 2.1.1 - December 20, 2024
  -  version to 16 consistent with base -domin-
- 
- ** mi-able?
+ -----
+- mixdom version 2.2.0 - date - December 26, 2024
+ - -mi estimate-able and usable with -mi_dom-

--- a/mixdom.sthlp
+++ b/mixdom.sthlp
@@ -1,18 +1,18 @@
 {smcl}
-{* *! version 2.1.1 December 20, 2024 J. N. Luchman}{...}
+{* *! version 2.2.0 December 26, 2024 J. N. Luchman}{...}
 {cmd:help mixdom}
 {hline}{...}
 
 {title:Title}
 
 {pstd}
-Wrapper program for {cmd:domin} to conduct linear mixed effects regression dominance analysis{p_end}
+Linear mixed effects regression wrapper program for {cmd:domin}{p_end}
 
 {title:Syntax}
 
 {phang}
-{cmd:mixdom} {it:depvar} {it:indepvars} {it:{help if}} {weight} {cmd:,} 
-{opt id(idvar)} [{opt {ul on}re{ul off}opt(re_options)} {opt {ul on}m{ul off}opt(mixed_options)}]
+{cmd:mixdom} {it:{help varname:depvar}} {it:{help varlist:indepvars}} [{it:{help if}}] {weight} {cmd:,} 
+{opt id(levelvar)} [{opt {ul on}re{ul off}opt(re_options)} {opt {ul on}m{ul off}opt(mixed_options)}]
 
 {phang}{cmd:pweight}s and {cmd:fweight}s are allowed (see help {help weights:weights}).  {help fvvarlist:Factor} and 
 {help tsvarlist:time series variables} are allowed.  
@@ -20,17 +20,17 @@ Wrapper program for {cmd:domin} to conduct linear mixed effects regression domin
 {title:Description}
 
 {pstd}
-{cmd:mixdom} sets the data up in a way to allow for the dominance analysis of a linear mixed effects regression by utilizing {help mixed}.
-The method outlined here follows that for the within- and between-cluster Snijders and Bosker (1994) R2 metric described by Luo and Azen (2013). 
+{cmd:mixdom} is a specialized {help mixed:linear mixed effects regression} command that is designed with a syntax structure that can be used in {help domin:dominance analysis}.
+{cmd:mixdom} also returns two model fit metrics recommended for use by Luo and Azen (2013).
+These two fit metrics are the the within- and between-cluster R2 metrics (Snijders & Bosker, 1994).
+In addition, consistent with Luo and Azen, {cmd:mixdom} only allows for one a random intercept associated with the cluster identifier variable in {opt id()}.
+For an example, see {cmd:domin}'s {help domin##examp:Example #8}.
 
 {pstd}
-{cmd:mixdom} only allows 1 level of clustering in the data (i.e., 1 random effect), which must be the cluster constant/mean/intercept. Luo and 
-Azen (2013) recommend that even if random coefficients are present in the data, they should be restricted to a fixed effect only in the dominance 
-analysis.
-
-{pstd}
-{cmd:mixdom} is intended for use only as a wrapper program with {cmd:domin} for the dominance analysis of mixed-effects linear regression, and its syntax is designed to conform with {cmd:domin}'s expectations.  
-It is not recommended for use as an estimation command outside of {cmd:domin}.
+{cmd:mixdom} is intended for use only as a wrapper program with {cmd:domin} and is not recommended for use as an estimation command outside of {cmd:domin}. 
+As of version 2.2.0, {cmd:mixdom} is compatible with {cmd:domin}'s {help mi_dom} wrapper command. 
+To do so, {cmd:mixdom} returns uninformative {cmd:b} and {cmd:V} matrices that are both values of 1.
+This is because {cmd:mixdom} is intended to be used only for its fit statistics and these two matrices are irrelevant for dominance analysis.
 
 {pstd}
 Note that negative R2 values indicate likely model misspecification.
@@ -38,13 +38,19 @@ Note that negative R2 values indicate likely model misspecification.
 {marker options}{...}
 {title:Options}
 
-{phang}{opt id()} specifies the variable on which clustering occurs and that will appear after the random effects specification (i.e., ||) in the 
-{cmd:mixed} syntax.
+{phang}{opt id()} is a required option that passes the clustering variable, {it:levelvar}, or cluster "id"entifier to {cmd:mixed}. 
+This is the variable that would appear after the random effects specification (i.e., {cmd:||}) in the {cmd:mixed} syntax. 
+For example, the command:
 
-{phang}{opt reopt()} passes options to {cmd: mixed} specific to the random intercept effect (i.e., {opt pweight()} the user would 
-like to utilize during estimation.
+{pmore}{cmd:mixdom depvar indepvars, id(levelvar)} 
 
-{phang}{opt mopt()} passes options to {cmd:mixed} that the user would like to utilize during estimation.
+{pmore}would be passed to {cmd:mixed} as:
+
+{pmore}{cmd:mixed depvar indepvars || levelvar:}
+
+{phang}{opt reopt()} passes options to the random intercept of {cmd:mixed} that will be included following its comma (e.g., {opt pweight()}).
+
+{phang}{opt mopt()} passes options to {cmd:mixed} that will be included following its comma (e.g., {opt pwscale()}).
 This option was named {opt xtmopt()} in {cmd:mixdom} versions previous to 2.0.0 and is now defunct.
 
 {title:Saved results}
@@ -56,7 +62,11 @@ This option was named {opt xtmopt()} in {cmd:mixdom} versions previous to 2.0.0 
 {synopt:{cmd:e(r2_w)}}within-cluster R2{p_end}
 {synopt:{cmd:e(r2_b)}}between-cluster R2{p_end}
 {p2col 5 15 19 2: macros}{p_end}
-{synopt:{cmd:e(title)}}"Mixed-effects ML regression"{p_end}
+{synopt:{cmd:e(title)}}title in estimation output{p_end}
+{synopt:{cmd:e(cmd)}}{cmd:mixdom}{p_end}
+{p2col 5 15 19 2: matrices}{p_end}
+{synopt:{cmd:e(b)}}1; required for {cmd:mi_dom}{p_end}
+{synopt:{cmd:e(V)}}1; required for {cmd:mi_dom}{p_end}
 {p2col 5 15 19 2: functions}{p_end}
 {synopt:{cmd:e(sample)}}marks estimation sample{p_end}
 

--- a/mvdom.ado
+++ b/mvdom.ado
@@ -1,134 +1,86 @@
-*! mvdom version 1.2.1 12/20/2024 Joseph N. Luchman
-
+*! mvdom version 1.3.0 12/28/2024 Joseph N. Luchman
+**# Program definition
 version 16
-
-program define mvdom, eclass
-
-syntax varlist(min = 2) [if] [aw fw], dvs(varlist min=1) [epsilon pxy] //epsilon is a hidden option
-
-tempname canonmat 
-
+program define mvdom, eclass properties(mi)
+syntax varlist(min = 2) [if] [aw fw], dvs(varlist min=1) [epsilon pxy]
+**# Set Stata environment
+tempname canonmat b V
 tempvar touse
-
+**# Parse inputs and prepare for analysis with markouts
 gettoken dv ivs: varlist
-
-quietly generate byte `touse' = 1 `if'
-	
-quietly replace `touse' = 0 if missing(`touse')
-
+mark `touse' [`weight'`exp'] `if'
+markout `touse' `varlist' `dvs'
+**# Implement -mvdom- estimation
 if strlen("`epsilon'") {
-
 	mata: eps_ri_mv("`dv' `dvs'", "`ivs'", "`touse'")
-	
 }
 else {
 	if strlen("`pxy'") {
-	
 		quietly correlate `dv' `dvs' `ivs' [`weight'`exp'] if `touse'
-		
 		local dvnum: word count `dv' `dvs'
-		
 		matrix `canonmat' = r(C)
-		
-		matrix `canonmat' = trace( ///
-		invsym(`canonmat'[1..`:word count `dv' `dvs'', 1..`:word count `dv' `dvs''])* ///
-		`canonmat'[`=`:word count `dv' `dvs''+1'..., 1..`:word count `dv' `dvs'']'* ///
-		invsym(`canonmat'[`=`:word count `dv' `dvs''+1'..., `=`:word count `dv' `dvs''+1'...])* ///
-		`canonmat'[`=`:word count `dv' `dvs''+1'..., 1..`:word count `dv' `dvs''] ///
-		)
-
+		matrix `canonmat' = trace(invsym(`canonmat'[1..`:word count `dv' `dvs'', 1..`:word count `dv' `dvs''])*`canonmat'[`=`:word count `dv' `dvs''+1'..., 1..`:word count `dv' `dvs'']'*invsym(`canonmat'[`=`:word count `dv' `dvs''+1'..., `=`:word count `dv' `dvs''+1'...])*`canonmat'[`=`:word count `dv' `dvs''+1'..., 1..`:word count `dv' `dvs''])
 	}
 	else {
-
 		quietly _canon (`dv' `dvs') (`ivs') [`weight'`exp'] if `touse'
-
 		matrix `canonmat' = e(ccorr)
-
 	}
-	
-	ereturn post, esample(`touse')
-	
-	if strlen("`pxy'") ereturn scalar r2 = `canonmat'[1, 1]/`:word count `dv' `dvs''
+**# Return values
+	matrix `b' = 1
+	matrix colnames `b' = "empty"
+	matrix `V' = 1
+	matrix colnames `V' =  "empty"
+	matrix rownames `V' =  "empty"
+	ereturn post `b' `V', esample(`touse')
+	if strlen("`pxy'") ///
+		ereturn scalar r2 = `canonmat'[1, 1]/`:word count `dv' `dvs''
 	else ereturn scalar r2 = `canonmat'[1, 1]^2
-	
+	ereturn local cmd "mvdom"
 	ereturn local title "Multivariate regression"
-	
 }
-
 end
-
-/*Mata function to execute epsilon-based relative importance with mvdom*/
+**# Mata function to execute epsilon-based relative importance with mvdom
 version 16
-
 mata: 
-
 mata set matastrict on
-
 void eps_ri_mv(string scalar dvlist, string scalar ivlist, string scalar touse) 
 {
 	/*object declarations*/
 	real matrix X, Y, L, R, Lm, L2, R2, Lm2, Pxy
-
 	real rowvector V, Bt, V2, Bt2
-	
 	transmorphic view_dv, view_iv
-	
-	/*begin processing*/
+	/*create views and basic set-up*/
 	st_view(view_dv, ., tokens(dvlist), st_varindex(touse))
-	
 	st_view(view_iv, ., tokens(ivlist), st_varindex(touse))
-	
 	Y = correlation(view_dv) //obtain DV correlations
-	
 	X = correlation(view_iv) //obtain IV correlations
-	
 	L = R = X //set-up for svd(); IV side
-	
 	L2 = R2 = Y //set-up for svd(); DV side
-	
 	V = J(1, cols(X), .) //placeholder for eigenvalues; IV side
-	
 	V2 = J(1, cols(Y), .) //placeholder for eigenvalues; DV side
-	
+	/*SVD processing*/
 	svd(X, L, V, R) //conduct singular value decomposition; IV side
-	
 	svd(Y, L2, V2, R2) //conduct singular value decomposition; DV side
-	
 	Lm = (L*diag(sqrt(V))*R) //process orthogonalized IVs
-	
 	Lm2 = (L2*diag(sqrt(V2))*R2) //process orthogonalized DVs
-	
+	/*obtain correlations*/
 	Pxy = correlation((view_iv, view_dv)) //correlation between original IVs and DVs
-	
 	Pxy = Pxy[rows(X)+1..rows(Pxy), 1..cols(X)] //take only IV-DV correlations
-	
 	Bt2 = Pxy'*invsym(Lm2)	//obtain adjusted DV interrelations
-	
+	/*construct epsilon components*/
 	Bt = invsym(Lm)*Bt2 //obtain adjusted regression weights
-	
 	Bt = Bt:^2 //square values of regression weights
-	
 	Lm = Lm:^2 //square values of orthogonalized predictors
-
+	/*return values*/
 	st_matrix("r(domwgts)", mean((Lm*Bt)'))	//produce proportion of variance explained and put into Stata
-	
 	st_numscalar("r(fs)", sum(mean((Lm*Bt)')))	//sum relative weights to obtain R2
-	
 }
-
 end
-
 /* programming notes and history
-
-- mvdom version 1.0 - date - Jan 15, 2014
-
+- mvdom version 1.0 - date - January 15, 2014
 Basic version
-
 -----
-
-- mvdom version 1.1 - date - March 11, 2015
-
-//notable changes\\
+mvdom version 1.1 - date - March 11, 2015
 - added version statement (12.1)
 - added the Pxy metric 
 - added the epsilon-based function
@@ -145,5 +97,8 @@ Basic version
  - use st_view as opposed to st_data for efficiency
  // 1.2.1 - December 20, 2024
  -  version to 16 consistent with base -domin-
+ ---
+ mvdom version 1.3.0 - December 28, 2024
+ - returns b and V matrices to be compatable with -mi_dom-
+ - fixed sample size determination with missing dependent or independent variables
  
- ** mi-able?

--- a/mvdom.sthlp
+++ b/mvdom.sthlp
@@ -1,41 +1,54 @@
 {smcl}
-{* *! version 1.2.1 December 20, 2024 J. N. Luchman}{...}
+{* *! version 1.3.0 December 28, 2024 J. N. Luchman}{...}
 {cmd:help mvdom}
 {hline}{...}
 
 {title:Title}
 
 {pstd}
-Wrapper program for {cmd:domin} to conduct multivariate regression-based dominance analysis{p_end}
+Multivariate regression wrapper program for {cmd:domin}{p_end}
 
 {title:Syntax}
 
 {phang}
-{cmd:mvdom} {it:depvar1} {it:indepvars} {it:{help if} {weight}} {cmd:,} 
+{cmd:mvdom} {it:{help varname:depvar1}} {it:{help varlist:indepvars}} [{it:{help if}}] {weight}} {cmd:,} 
 {opt dvs(depvar2 [... depvar_r])} [{opt pxy} {opt epsilon}]
 
-{phang}{cmd:aweight}s and {cmd:fweight}s are allowed (see help {help weights:weights}).  {help fvvarlist: Factor} and {help tsvarlist:time series variables} are not allowed.  Use the {help xi} prefix for factor variables.
+{phang}{cmd:aweight}s and {cmd:fweight}s are allowed (see help {help weights:weights}).  {help fvvarlist: Factor} and {help tsvarlist:time series variables} are not allowed.
 
 {title:Description}
 
 {pstd}
-{cmd:mvdom} sets the data up in a way to allow for the dominance analysis of a multivariate regression by utilizing {help canon}ical correlation. The default metric used is the Rxy metric described by Azen and Budescu (2006). 
+{cmd:mvdom} is a specialized {help mvreg:multivariate regression} command that is designed with a syntax structure that can be used in {help domin:dominance analysis}.
+{cmd:mvdom} also returns one of two model fit metrics recommended for use by Azen and Budescu (2006).
+These two fit metrics are the the {it:Rxy} and {it:Pxy} discussed by Van den Berg and Lewis (1988).
+For an example, see {cmd:domin}'s {help domin##examp:Example #6}.
 
 {pstd}
-{cmd:mvdom} uses the first variable in the {it:varlist} as the first dependent variable in the multivariate regression.  All other variables in the {it:varlist} are used as independent variables.  All dependent variables after the first are entered into the regression in the {opt dvs()} option. {cmd:domin} will only show the first dependent variable in the output.
+{cmd:mvdom} uses the standard {it:depvar indepvars} syntax common to many estimation commands in Stata but extends on it by allowing additional {it:depvars} to be submitted in the {opt dvs()} option.
+{cmd:mvdom} requires at least two dependent variables, one submitted in the primary variable list (i.e., {it:depvar1}) and one or more submitted in the {opt dvs()} option (i.e., {it:depvar2 ... depvar_r}).
+Note that {cmd:domin} will only show the first dependent variable submitted in the output although all are used in model estimation.
 
 {pstd}
-{cmd:mvdom} is intended for use only as a wrapper program with {cmd:domin} for the dominance analysis of multivariate linear regression, and its syntax is designed to conform with {cmd:domin}'s expectations. 
-It is not recommended for use as an estimation command outside of {cmd:domin}.
+{cmd:mixdom} is intended for use only as a wrapper program with {cmd:domin} and is not recommended for use as an estimation command outside of {cmd:domin}. 
+As of version 1.3.0, {cmd:mvdom} is compatible with {cmd:domin}'s {help mi_dom} wrapper command. 
+To do so, {cmd:mvdom} returns uninformative {cmd:b} and {cmd:V} matrices that are both values of 1.
+This is because {cmd:mvdom} is intended to be used only for its fit statistics and these two matrices are irrelevant for dominance analysis.
+
+{pstd}
+{cmd:mvdom} uses {help canon:canonical correlation} as its underlying estimation engine.
 
 {marker options}{...}
 {title:Options}
 
-{phang}{opt dvs(depvar2 [... depvar_r])} specifies the second through {it:r}th other dependent variables to be used in the multivariate regression. Note the first dependent variable, depvar1, as shown in the syntax. dvs() is required.
+{phang}{opt dvs(depvar2 [... depvar_r])} is a required option that specifies the second through {it:r}th dependent variables to be used in the multivariate regression. 
+Note the first dependent variable, {it:depvar1}, is submitted in the overall variable list. 
+{opt dvs()} must have at least one variable.
 
-{phang}{opt pxy} changes the fit statistic from the default "symmetric" {it:Rxy} to the "nonsymmetric" {it:Pxy} model fit statistic. Both fit statistics are described by Azen and Budescu (2006).
+{phang}{opt pxy} changes the fit statistic from the default "symmetric" {it:Rxy} to the "nonsymmetric" {it:Pxy} model fit statistic.
 
-{phang}{opt epsilon} changes the decomposition estimation method to relative weights estimation method described by LeBreton & Tonidandel (2008). The {opt epsilon} method produces a decomposition of the {it:Pxy} statistic.
+{phang}{opt epsilon} changes the decomposition estimation method to relative weights estimation method described by LeBreton and Tonidandel (2008). 
+The {opt epsilon} method produces a decomposition of the {it:Pxy} statistic.
 
 {title:Saved results}
 
@@ -46,6 +59,10 @@ It is not recommended for use as an estimation command outside of {cmd:domin}.
 {synopt:{cmd:e(r2)}}{it:Rxy} metric (default) or {it:Pxy} metric (with option {opt pxy}){p_end}
 {p2col 5 15 19 2: macros}{p_end}
 {synopt:{cmd:e(title)}}"Multivariate regression"{p_end}
+{synopt:{cmd:e(cmd)}}{cmd:mvdom}{p_end}
+{p2col 5 15 19 2: matrices}{p_end}
+{synopt:{cmd:e(b)}}1; required for {cmd:mi_dom}{p_end}
+{synopt:{cmd:e(V)}}1; required for {cmd:mi_dom}{p_end}
 {p2col 5 15 19 2: functions}{p_end}
 {synopt:{cmd:e(sample)}}marks estimation sample{p_end}
 
@@ -53,6 +70,7 @@ It is not recommended for use as an estimation command outside of {cmd:domin}.
 
 {p 4 8 2}Azen, R., & Budescu, D. V. (2006). Comparing predictors in multivariate regression models: An extension of dominance analysis. {it:Journal of Educational and Behavioral Statistics, 31(2)}, 157-180.{p_end}
 {p 4 8 2}LeBreton, J. M., & Tonidandel, S. (2008). Multivariate relative importance: Extending relative weight analysis to multivariate criterion spaces. {it:Journal of Applied Psychology, 93(2)}, 329-345.{p_end}
+{p 4 8 2}Van den Burg, W., & Lewis, C. (1988). Some properties of two measures of multivariate association. {it:Psychometrika, 53}, 109-122.{p_end}
 
 {title:Author}
 


### PR DESCRIPTION
 - bugfix introduced in 3.5.3 when there are no regular IVs and two or more sets
 - -mvdom- and -mixdom- compatible with -mi_dom-
 - update complete dominance designations to complete dominance proportions
 - update display on complete and conditional dominance matrices